### PR TITLE
CSS styles and SVG trimming fix

### DIFF
--- a/src/js/components/Forecast.styles.js
+++ b/src/js/components/Forecast.styles.js
@@ -14,7 +14,8 @@ const useStyles = createUseStyles({
   day: {
     width: '25%',
     textAlign: 'center',
-    margin: 10,
+    margin: '10px 0',
+    padding: '0 10px',
     '&:not(:first-child)': {
       borderLeft: ({ theme }) => `solid 1px ${theme.forecastSeparatorColor}`,
     },

--- a/src/js/components/WeatherIcon.js
+++ b/src/js/components/WeatherIcon.js
@@ -37,7 +37,7 @@ WeatherIcon.propTypes = {
 WeatherIcon.defaultProps = {
   color: '#4BC4F7',
   size: 40,
-  viewBox: '0 0 35 40',
+  viewBox: '0 -5 35 40',
 };
 
 export default WeatherIcon;

--- a/tests/__snapshots__/Forecast.test.js.snap
+++ b/tests/__snapshots__/Forecast.test.js.snap
@@ -20,7 +20,7 @@ exports[`Forecast should render the Forecast component 1`] = `
         className="svg-0-2-12 svg-d0-0-2-13"
         height={40}
         version="1.1"
-        viewBox="0 0 35 40"
+        viewBox="0 -5 35 40"
         width={40}
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -62,7 +62,7 @@ exports[`Forecast should render the Forecast component 1`] = `
         className="svg-0-2-12 svg-d1-0-2-14"
         height={40}
         version="1.1"
-        viewBox="0 0 35 40"
+        viewBox="0 -5 35 40"
         width={40}
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -104,7 +104,7 @@ exports[`Forecast should render the Forecast component 1`] = `
         className="svg-0-2-12 svg-d2-0-2-15"
         height={40}
         version="1.1"
-        viewBox="0 0 35 40"
+        viewBox="0 -5 35 40"
         width={40}
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -146,7 +146,7 @@ exports[`Forecast should render the Forecast component 1`] = `
         className="svg-0-2-12 svg-d3-0-2-16"
         height={40}
         version="1.1"
-        viewBox="0 0 35 40"
+        viewBox="0 -5 35 40"
         width={40}
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/tests/__snapshots__/ReactWeather.test.js.snap
+++ b/tests/__snapshots__/ReactWeather.test.js.snap
@@ -73,7 +73,7 @@ exports[`ReactWeather should render the ReactWeather component 1`] = `
         className="svg-0-2-19 svg-d0-0-2-20"
         height={120}
         version="1.1"
-        viewBox="0 0 35 40"
+        viewBox="0 -5 35 40"
         width={120}
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -105,7 +105,7 @@ exports[`ReactWeather should render the ReactWeather component 1`] = `
           className="svg-0-2-19 svg-d1-0-2-32"
           height={40}
           version="1.1"
-          viewBox="0 0 35 40"
+          viewBox="0 -5 35 40"
           width={40}
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -147,7 +147,7 @@ exports[`ReactWeather should render the ReactWeather component 1`] = `
           className="svg-0-2-19 svg-d2-0-2-33"
           height={40}
           version="1.1"
-          viewBox="0 0 35 40"
+          viewBox="0 -5 35 40"
           width={40}
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -189,7 +189,7 @@ exports[`ReactWeather should render the ReactWeather component 1`] = `
           className="svg-0-2-19 svg-d3-0-2-34"
           height={40}
           version="1.1"
-          viewBox="0 0 35 40"
+          viewBox="0 -5 35 40"
           width={40}
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -231,7 +231,7 @@ exports[`ReactWeather should render the ReactWeather component 1`] = `
           className="svg-0-2-19 svg-d4-0-2-35"
           height={40}
           version="1.1"
-          viewBox="0 0 35 40"
+          viewBox="0 -5 35 40"
           width={40}
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/tests/__snapshots__/WeatherIcon.test.js.snap
+++ b/tests/__snapshots__/WeatherIcon.test.js.snap
@@ -5,7 +5,7 @@ exports[`WeatherIcon render WeatherIcon 1`] = `
   className="svg-0-2-1 svg-d0-0-2-2"
   height={120}
   version="1.1"
-  viewBox="0 0 35 40"
+  viewBox="0 -5 35 40"
   width={120}
   xmlns="http://www.w3.org/2000/svg"
 >


### PR DESCRIPTION
Hi,

I noticed that icons and styling are a bit broken:
![before](https://user-images.githubusercontent.com/2486362/114187996-5016bc00-9951-11eb-911b-f87cb10ca19b.png)

So I prepared a small PR fixing this:
![after](https://user-images.githubusercontent.com/2486362/114188029-5a38ba80-9951-11eb-9ff3-e66607f1f486.png)

Thanks in advance.