### PR TITLE
Use "this" as a globalObject in webpack

### DIFF
--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -10,6 +10,7 @@ module.exports = {
     libraryTarget: 'umd',
     library: 'ReactWeather',
     umdNamedDefine: true,
+    globalObject: 'this'
   },
   devtool: false,
   module: {


### PR DESCRIPTION
Fix issue: https://github.com/farahat80/react-open-weather/issues/50 

Use "this" instead of "self" as a global object to avoid referenceError 