### PR TITLE
Prefix endpoint with https:// to allow bundles to correctly call api

### DIFF
--- a/src/js/providers/openweather/useOpenWeather.js
+++ b/src/js/providers/openweather/useOpenWeather.js
@@ -81,7 +81,7 @@ export const fetchReducer = (state, { type, payload }) => {
 };
 
 const useOpenWeather = (options) => {
-  const endpoint = '//api.openweathermap.org/data/2.5/onecall';
+  const endpoint = 'https://api.openweathermap.org/data/2.5/onecall';
   const [state, dispatch] = useReducer(fetchReducer, initialState);
   const { data, errorMessage } = state;
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
If the react-open-weather is included in a bundle and statically loaded, the endpoint defaults to file:// and does not make the request to open weather API. this change fixes that.